### PR TITLE
Adding option to disable security context

### DIFF
--- a/library/templates/_deployment.tpl
+++ b/library/templates/_deployment.tpl
@@ -14,9 +14,11 @@ spec:
       {{- (include "hmcts.annotations.v1" .) | indent 6 }}
     spec:
       {{- ( include "hmcts.interpodantiaffinity.v1" . ) | indent 6 }}
+      {{- if (not .Values.disableSecurityContext) }}
       securityContext:
         runAsUser: 1000
         fsGroup: 1000
+      {{- end -}}
       {{- ( include "hmcts.secretVolumes.v1" . ) | indent 6 }}
       {{- ( include "hmcts.dnsConfig.v1" . ) | indent 6 }}
       containers:


### PR DESCRIPTION
Current security context setting are not compatible with windows images. https://kubernetes.io/docs/setup/production-environment/windows/intro-windows-in-kubernetes/#security . 

For future, windowssecuritycontextoptions described in https://kubernetes.cn/docs/tasks/configure-pod-container/configure-runasusername/  is alpha in kubernetes and not supported on AKS.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
