### PR TITLE
fix multiple keyvaults SecretProviderClass

### DIFF
--- a/library/templates/_secretproviderclass.tpl
+++ b/library/templates/_secretproviderclass.tpl
@@ -4,6 +4,7 @@
 {{- $keyVaults := .Values.keyVaults }}
 {{- $root := . }}
 {{- range $vault, $info := .Values.keyVaults }}
+---
 apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
 kind: SecretProviderClass
 metadata:

--- a/tests/results/template-secretproviderclass.yaml
+++ b/tests/results/template-secretproviderclass.yaml
@@ -1,5 +1,6 @@
 ---
 # Source: library/templates/secretproviderclass.yaml
+
 apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
 kind: SecretProviderClass
 metadata:
@@ -19,6 +20,7 @@ spec:
           objectName: s2s-secret
           objectType: secret
     tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
+---
 apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
 kind: SecretProviderClass
 metadata:


### PR DESCRIPTION
Currently only the second/last SecretProviderClass is getting created due to missing separator  

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
