### PR TITLE
Adding support for secretprovider alias

### DIFF
--- a/ci-values-lang.yaml
+++ b/ci-values-lang.yaml
@@ -140,8 +140,9 @@ java:
     bulk-scan:
       excludeEnvironmentSuffix: false
       secrets:
-        - idam-client-secret
-        - s2s-secret
+        - name: idam-client-secret
+          alias: idam.client.secret
+        - name: s2s-secret
   additionalPathBasedRoutes:
     "/test": "{{.Release.Name}}"
   secrets:

--- a/ci-values.yaml
+++ b/ci-values.yaml
@@ -50,8 +50,9 @@ keyVaults:
   bulk-scan:
     excludeEnvironmentSuffix: false
     secrets:
-      - idam-client-secret
-      - s2s-secret
+      - name: idam-client-secret
+        alias: idam.client.secret
+      - name: s2s-secret
 additionalPathBasedRoutes:
   "/test": "{{.Release.Name}}"
 secrets:

--- a/library/templates/v1/_secretproviderclass.tpl
+++ b/library/templates/v1/_secretproviderclass.tpl
@@ -21,7 +21,9 @@ spec:
         - |
           objectName: {{ .name }}
           objectType: secret
+     {{- if hasKey . "alias" }}
           objectAlias: {{ .alias }}
+     {{- end }}
      {{- else }}
         - |
           objectName: {{ . }}

--- a/library/templates/v1/_secretproviderclass.tpl
+++ b/library/templates/v1/_secretproviderclass.tpl
@@ -17,10 +17,17 @@ spec:
     keyvaultName: "{{ $vault }}{{ if not (default $info.excludeEnvironmentSuffix false) }}-{{ $globals.environment }}{{ end }}"
     objects: |
       array: {{- range $info.secrets }}
+     {{- if kindIs "map" . }}
+        - |
+          objectName: {{ .name }}
+          objectType: secret
+          objectAlias: {{ .alias }}
+     {{- else }}
         - |
           objectName: {{ . }}
           objectType: secret
-      {{- end }}
+     {{- end }}
+     {{- end }}
     tenantId: {{ $globals.tenantId | quote }}
 {{- end }}
 {{- end }}

--- a/library/templates/v2/_secretproviderclass.tpl
+++ b/library/templates/v2/_secretproviderclass.tpl
@@ -18,9 +18,16 @@ spec:
     keyvaultName: "{{ $vault }}{{ if not (default $info.excludeEnvironmentSuffix false) }}-{{ $globals.environment }}{{ end }}"
     objects: |
       array: {{- range $info.secrets }}
+     {{- if kindIs "map" . }}
+        - |
+          objectName: {{ .name }}
+          objectType: secret
+          objectAlias: {{ .alias }}
+     {{- else }}
         - |
           objectName: {{ . }}
           objectType: secret
+     {{- end }}
       {{- end }}
     tenantId: {{ $globals.tenantId | quote }}
 {{- end }}

--- a/library/templates/v2/_secretproviderclass.tpl
+++ b/library/templates/v2/_secretproviderclass.tpl
@@ -22,7 +22,9 @@ spec:
         - |
           objectName: {{ .name }}
           objectType: secret
+     {{- if hasKey . "alias" }}
           objectAlias: {{ .alias }}
+     {{- end }}
      {{- else }}
         - |
           objectName: {{ . }}

--- a/tests/results/secretproviderclass.yaml
+++ b/tests/results/secretproviderclass.yaml
@@ -15,7 +15,9 @@ spec:
         - |
           objectName: idam-client-secret
           objectType: secret
+          objectAlias: idam.client.secret
         - |
           objectName: s2s-secret
           objectType: secret
+          objectAlias:
     tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"

--- a/tests/results/secretproviderclass.yaml
+++ b/tests/results/secretproviderclass.yaml
@@ -19,5 +19,4 @@ spec:
         - |
           objectName: s2s-secret
           objectType: secret
-          objectAlias:
     tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-578 

- Adding objectAlias will give us an option to set/ override the name of file mounted to a different name (an Env var or spring property for example). 
- This helps us manage secret to Env var mapping when using spring boot 2.4 config tree. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
