### PR TITLE
Fix sticky sessions annotations for traefik v2

### DIFF
--- a/library/templates/v2/_service.tpl
+++ b/library/templates/v2/_service.tpl
@@ -16,8 +16,8 @@ metadata:
   {{- if hasKey $languageValues "ingressSessionAffinity" }}
   {{- if and $languageValues.ingressSessionAffinity $languageValues.ingressSessionAffinity.enabled }}
   annotations:
-    traefik.ingress.kubernetes.io/affinity: "true"
-    traefik.ingress.kubernetes.io/session-cookie-name: {{ $languageValues.ingressSessionAffinity.sessionCookieName | quote }}
+    traefik.ingress.kubernetes.io/service.sticky.cookie: "true"
+    traefik.ingress.kubernetes.io/session.cookie.name: {{ $languageValues.ingressSessionAffinity.sessionCookieName | quote }}
   {{- end }}
   {{- end }}
 spec:


### PR DESCRIPTION
### Change description ###
Doesn't look like session affinity is being used by anyone other than JD and this change is for them as the annotations are no longer working and have been updated in traefik V2, so this change looks safe to me. I think we also only use traefik v1 on the old sds clusters which are being removed after this work has been completed, so the current annotations would have 0 effect anyway.

I have tested manually and these annotations work. 

Docs for new annotations: https://doc.traefik.io/traefik/routing/providers/kubernetes-ingress/#on-service


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
