### PR TITLE
Add certificate support in helm

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,10 +149,47 @@ keyVaults:
           alias: <SECRET_ALIAS2>
 ```
 
+#### Example for adding Azure Key Vault Certificates
+Key vault certificates can be mounted to the container filesystem using what's called a [secrets-store-csi-driver-provider-azure](https://github.com/Azure/secrets-store-csi-driver-provider-azure). This means that the keyvault certificates are accessible as files after they have been mounted.
+To do this you need to add the **keyVaults** section to the configuration.
+```yaml
+aadIdentityName: <Identity Binding>
+keyVaults:
+    <VAULT_NAME>:
+      excludeEnvironmentSuffix: true
+      disabled: true
+      certs:
+        - <CERT_NAME>
+        - <CERT_NAME2>
+    <VAULT_NAME_2>:
+      certs:
+        - <CERT_NAME>
+        - <CERT_NAME2>
+```
+
+#### Example for adding Azure Key Vault Certificates using aliases
+In some cases, you may want to alias the certificates to a different name (An environment variable for example), you can configure it using
+
+```yaml
+aadIdentityName: <Identity Binding>
+keyVaults:
+    <VAULT_NAME>:
+      excludeEnvironmentSuffix: true
+      certs:
+        - name: <CERT_NAME>
+          alias: <CERT_ALIAS>
+        - name: <CERT_NAME2>
+          alias: <CERT_ALIAS2>
+```
+
+
 **Where**:
 - *<VAULT_NAME>*: Name of the vault to access without the environment tag i.e. `s2s` or `bulkscan`.
 - *<SECRET_NAME>*: Secret name as it is in the vault. Note this is case and punctuation sensitive. i.e. in s2s there is the `microservicekey-cmcLegalFrontend` secret.
 - *<SECRET_ALIAS>*: Alias name for the secret.
+- *excludeEnvironmentSuffix*: This is used for the global key vaults 
+- *<CERT_NAME>*: Certificate name as it is in the vault. Note this is case and punctuation sensitive. i.e. in s2s there is the `microservicekey-cmcLegalFrontend` certificate.
+- *<CERT_ALIAS>*: Alias name for the certificate.
 - *excludeEnvironmentSuffix*: This is used for the global key vaults where there is not environment suffix ( e.g `-aat` ) required. It defaults to false if it is not there and should only be added if you are using a global key-vault.
 - *disabled*: This is an optional field used to disable a specific key vault, useful when overriding defaults.
 - When not using Jenkins, explicitly set global.enableKeyVaults to `true` .

--- a/ci-values-lang.yaml
+++ b/ci-values-lang.yaml
@@ -56,6 +56,10 @@ keyVaults:
       - name: idam-client-secret
         alias: idam.client.secret
       - name: s2s-secret
+    certs:
+      - name: idam-client-cert
+        alias: idam.client.cert
+      - name: s2s-cert
 additionalPathBasedRoutes:
   "/test": "{{.Release.Name}}"
 secrets:
@@ -81,6 +85,10 @@ testsConfig:
           - name: idam-client-secret
             alias: IDAM_CLIENT_SECRET
           - name: s2s-secret
+        certs:
+          - name: idam-client-cert
+            alias: IDAM_CLIENT_CERT
+          - name: s2s-cert
 smoketests:
   image: hmctspublic.azurecr.io/boot/template
   enabled: false
@@ -162,6 +170,10 @@ java:
         - name: idam-client-secret
           alias: idam.client.secret
         - name: s2s-secret
+      certs:
+        - name: idam-client-cert
+          alias: idam.client.cert
+        - name: s2s-cert
   additionalPathBasedRoutes:
     "/test": "{{.Release.Name}}"
   secrets:
@@ -187,6 +199,10 @@ java:
           - name: idam-client-secret
             alias: IDAM_CLIENT_SECRET
           - name: s2s-secret
+        certs:
+          - name: idam-client-cert
+            alias: IDAM_CLIENT_CERT
+          - name: s2s-cert
   smoketests:
     image: hmctspublic.azurecr.io/spring-boot/template
     enabled: false

--- a/ci-values.yaml
+++ b/ci-values.yaml
@@ -59,6 +59,10 @@ keyVaults:
       - name: idam-client-secret
         alias: idam.client.secret
       - name: s2s-secret
+    certs:
+      - name: idam-client-cert
+        alias: idam.client.cert
+      - name: s2s-cert
 additionalPathBasedRoutes:
   "/test": "{{.Release.Name}}"
 secrets:
@@ -84,6 +88,10 @@ testsConfig:
         - name: idam-client-secret
           alias: IDAM_CLIENT_SECRET
         - name: s2s-secret
+      certs:
+        - name: idam-client-cert
+          alias: IDAM_CLIENT_CERT
+        - name: s2s-cert
 smoketests:
   image: hmctspublic.azurecr.io/spring-boot/template
   enabled: false

--- a/library/templates/v2/_secretproviderclass-tests.tpl
+++ b/library/templates/v2/_secretproviderclass-tests.tpl
@@ -35,6 +35,20 @@ spec:
           objectType: secret
      {{- end }}
       {{- end }}
+      {{- range $info.certs }}
+     {{- if kindIs "map" . }}
+        - |
+          objectName: {{ .name }}
+          objectType: cert
+        {{- if hasKey . "alias" }}
+          objectAlias: {{ .alias }}
+        {{- end }}
+     {{- else }}
+        - |
+          objectName: {{ . }}
+          objectType: cert
+     {{- end }}
+      {{- end }}
     tenantId: {{ $globals.tenantId | quote }}
 {{- end }}
 {{- end }}

--- a/library/templates/v2/_secretproviderclass.tpl
+++ b/library/templates/v2/_secretproviderclass.tpl
@@ -1,4 +1,4 @@
-{{- define "hmcts.secretproviderclass.v2.tpl" -}}
+{{- define "hmcts.secretproviderclass.v3.tpl" -}}
 {{- $languageValues := deepCopy .Values -}}
 {{- if hasKey .Values "language" -}}
 {{- $languageValues = (deepCopy .Values | merge (pluck .Values.language .Values | first) ) -}}
@@ -57,5 +57,5 @@ spec:
 {{- end -}}
 
 {{- define "hmcts.secretproviderclass.v2" -}}
-{{- template "hmcts.util.merge.v2" (append . "hmcts.secretproviderclass.v2.tpl") -}}
+{{- template "hmcts.util.merge.v2" (append . "hmcts.secretproviderclass.v3.tpl") -}}
 {{- end -}}

--- a/library/templates/v2/_secretproviderclass.tpl
+++ b/library/templates/v2/_secretproviderclass.tpl
@@ -56,6 +56,6 @@ spec:
 {{- end }}
 {{- end -}}
 
-{{- define "hmcts.secretproviderclass.v2" -}}
+{{- define "hmcts.secretproviderclass.v3" -}}
 {{- template "hmcts.util.merge.v2" (append . "hmcts.secretproviderclass.v3.tpl") -}}
 {{- end -}}

--- a/library/templates/v2/_secretproviderclass.tpl
+++ b/library/templates/v2/_secretproviderclass.tpl
@@ -35,6 +35,21 @@ spec:
           objectType: secret
      {{- end }}
       {{- end }}
+
+      {{- range $info.certs }}
+     {{- if kindIs "map" . }}
+        - |
+          objectName: {{ .name }}
+          objectType: cert
+     {{- if hasKey . "alias" }}
+          objectAlias: {{ .alias }}
+     {{- end }}
+     {{- else }}
+        - |
+          objectName: {{ . }}
+          objectType: cert
+     {{- end }}
+      {{- end }}
     tenantId: {{ $globals.tenantId | quote }}
 {{- end }}
 {{- end }}

--- a/tests/results/secretproviderclass-tests.yaml
+++ b/tests/results/secretproviderclass-tests.yaml
@@ -19,4 +19,11 @@ spec:
         - |
           objectName: s2s-secret
           objectType: secret
+        - |
+          objectName: idam-client-cert
+          objectType: cert
+          objectAlias: IDAM_CLIENT_CERT
+        - |
+          objectName: s2s-cert
+          objectType: cert
     tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"

--- a/tests/results/secretproviderclass.yaml
+++ b/tests/results/secretproviderclass.yaml
@@ -19,4 +19,11 @@ spec:
         - |
           objectName: s2s-secret
           objectType: secret
+        - |
+          objectName: idam-client-cert
+          objectType: cert
+          objectAlias: idam.client.cert
+        - |
+          objectName: s2s-cert
+          objectType: cert
     tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"

--- a/tests/v2/secretproviderclass.yaml
+++ b/tests/v2/secretproviderclass.yaml
@@ -1,1 +1,1 @@
-{{- template "hmcts.secretproviderclass.v2.tpl" . -}}
+{{- template "hmcts.secretproviderclass.v3.tpl" . -}}


### PR DESCRIPTION
### JIRA link (if applicable) ###
Doc: https://docs.microsoft.com/en-us/azure/aks/csi-secrets-store-driver#obtain-certificates-and-keys
Example: https://github.com/hmcts/pip-frontend/pull/297

### Change description ###
Currently Certificates are not being mounted to the pods like secrets.
This will allow the users to add the certs to the Helm Values and mount them.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X ] No
```
