### PR TITLE
Environment replacement on secret names

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,21 @@ keyVaults:
           alias: <SECRET_ALIAS2>
 ```
 
+#### Example for adding Environment Name to Azure Key Vault Secrets
+In some cases, you may want to have the environment name in the secret name, you can configure it by adding `<ENV>` in the secret name
+
+```yaml
+aadIdentityName: <Identity Binding>
+keyVaults:
+    <VAULT_NAME>:
+      excludeEnvironmentSuffix: true
+      secrets:
+        - name: example-secret-<ENV>
+          alias: <SECRET_ALIAS>
+        - name: secret-<ENV>-example
+```
+
+
 #### Example for adding Azure Key Vault Certificates
 Key vault certificates can be mounted to the container filesystem using what's called a [secrets-store-csi-driver-provider-azure](https://github.com/Azure/secrets-store-csi-driver-provider-azure). This means that the keyvault certificates are accessible as files after they have been mounted.
 To do this you need to add the **keyVaults** section to the configuration.

--- a/ci-values-lang.yaml
+++ b/ci-values-lang.yaml
@@ -57,6 +57,9 @@ keyVaults:
       - name: idam-client-secret
         alias: idam.client.secret
       - name: s2s-secret
+      - name: idam-client-<ENV>-secret
+        alias: idam.client.env.secret
+      - name: s2s-<ENV>-secret
     certs:
       - name: idam-client-cert
         alias: idam.client.cert
@@ -86,6 +89,9 @@ testsConfig:
           - name: idam-client-secret
             alias: IDAM_CLIENT_SECRET
           - name: s2s-secret
+          - name: idam-client-<ENV>-secret
+            alias: idam.client.env.secret
+          - name: s2s-<ENV>-secret
         certs:
           - name: idam-client-cert
             alias: IDAM_CLIENT_CERT
@@ -171,6 +177,9 @@ java:
         - name: idam-client-secret
           alias: idam.client.secret
         - name: s2s-secret
+        - name: idam-client-<ENV>-secret
+          alias: idam.client.env.secret
+        - name: s2s-<ENV>-secret
       certs:
         - name: idam-client-cert
           alias: idam.client.cert
@@ -200,6 +209,9 @@ java:
           - name: idam-client-secret
             alias: IDAM_CLIENT_SECRET
           - name: s2s-secret
+          - name: idam-client-<ENV>-secret
+            alias: idam.client.env.secret
+          - name: s2s-<ENV>-secret
         certs:
           - name: idam-client-cert
             alias: IDAM_CLIENT_CERT

--- a/ci-values.yaml
+++ b/ci-values.yaml
@@ -60,6 +60,9 @@ keyVaults:
       - name: idam-client-secret
         alias: idam.client.secret
       - name: s2s-secret
+      - name: idam-client-<ENV>-secret
+        alias: idam.client.env.secret
+      - name: s2s-<ENV>-secret
     certs:
       - name: idam-client-cert
         alias: idam.client.cert
@@ -89,6 +92,9 @@ testsConfig:
         - name: idam-client-secret
           alias: IDAM_CLIENT_SECRET
         - name: s2s-secret
+        - name: idam-client-<ENV>-secret
+          alias: idam.client.env.secret
+        - name: s2s-<ENV>-secret
       certs:
         - name: idam-client-cert
           alias: IDAM_CLIENT_CERT

--- a/library/templates/v2/_secretproviderclass.tpl
+++ b/library/templates/v2/_secretproviderclass.tpl
@@ -31,7 +31,7 @@ spec:
      {{- end }}
      {{- else }}
         - |
-          objectName: {{ . }}
+          objectName: {{ . | replace "<ENV>" $globals.environment }} 
           objectType: secret
      {{- end }}
       {{- end }}

--- a/library/templates/v2/_secretproviderclass.tpl
+++ b/library/templates/v2/_secretproviderclass.tpl
@@ -12,7 +12,7 @@
 ---
 apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
 kind: SecretProviderClass
-metadata:
+metadata
   name: {{ template "hmcts.releasename.v2" $root }}-{{ $vault }}
 spec:
   provider: azure
@@ -24,7 +24,7 @@ spec:
       array: {{- range $info.secrets }}
      {{- if kindIs "map" . }}
         - |
-          objectName: {{ .name }}
+          objectName: {{ .name | replace "<ENV>" $globals.environment }} 
           objectType: secret
      {{- if hasKey . "alias" }}
           objectAlias: {{ .alias }}

--- a/library/templates/v2/_secretproviderclass.tpl
+++ b/library/templates/v2/_secretproviderclass.tpl
@@ -12,7 +12,7 @@
 ---
 apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
 kind: SecretProviderClass
-metadata
+metadata:
   name: {{ template "hmcts.releasename.v2" $root }}-{{ $vault }}
 spec:
   provider: azure

--- a/tests/results/deployment-tests.yaml
+++ b/tests/results/deployment-tests.yaml
@@ -35,7 +35,7 @@ spec:
           containers:
             - name: tests
               image: hmctspublic.azurecr.io/spring-boot/template
-              args: ["IDAM_CLIENT_SECRET=/mnt/secrets/bulk-scan/IDAM_CLIENT_SECRET","S2S_SECRET=/mnt/secrets/bulk-scan/s2s-secret"]
+              args: ["IDAM_CLIENT_SECRET=/mnt/secrets/bulk-scan/IDAM_CLIENT_SECRET","S2S_SECRET=/mnt/secrets/bulk-scan/s2s-secret","idam.client.env.secret=/mnt/secrets/bulk-scan/idam.client.env.secret","S2S_<ENV>_SECRET=/mnt/secrets/bulk-scan/s2s-<ENV>-secret"]
               securityContext:
                 allowPrivilegeEscalation: false
               volumeMounts:

--- a/tests/results/secretproviderclass-tests.yaml
+++ b/tests/results/secretproviderclass-tests.yaml
@@ -20,6 +20,13 @@ spec:
           objectName: s2s-secret
           objectType: secret
         - |
+          objectName: idam-client-prod-secret
+          objectType: secret
+          objectAlias: IDAM_CLIENT_SECRET
+        - |
+          objectName: s2s-prod-secret
+          objectType: secret
+        - |
           objectName: idam-client-cert
           objectType: cert
           objectAlias: IDAM_CLIENT_CERT

--- a/tests/results/secretproviderclass-tests.yaml
+++ b/tests/results/secretproviderclass-tests.yaml
@@ -20,11 +20,11 @@ spec:
           objectName: s2s-secret
           objectType: secret
         - |
-          objectName: idam-client-prod-secret
+          objectName: idam-client-<ENV>-secret
           objectType: secret
-          objectAlias: IDAM_CLIENT_SECRET
+          objectAlias: idam.client.env.secret
         - |
-          objectName: s2s-prod-secret
+          objectName: s2s-<ENV>-secret
           objectType: secret
         - |
           objectName: idam-client-cert

--- a/tests/results/secretproviderclass.yaml
+++ b/tests/results/secretproviderclass.yaml
@@ -20,11 +20,11 @@ spec:
           objectName: s2s-secret
           objectType: secret
         - |
-          objectName: idam-client-prod-secret
+          objectName: idam-client-aat-secret
           objectType: secret
-          objectAlias: IDAM_CLIENT_ENV_SECRET
+          objectAlias: idam.client.env.secret
         - |
-          objectName: s2s-prod-secret
+          objectName: s2s-aat-secret
           objectType: secret
         - |
           objectName: idam-client-cert

--- a/tests/results/secretproviderclass.yaml
+++ b/tests/results/secretproviderclass.yaml
@@ -20,6 +20,13 @@ spec:
           objectName: s2s-secret
           objectType: secret
         - |
+          objectName: idam-client-prod-secret
+          objectType: secret
+          objectAlias: IDAM_CLIENT_ENV_SECRET
+        - |
+          objectName: s2s-prod-secret
+          objectType: secret
+        - |
           objectName: idam-client-cert
           objectType: cert
           objectAlias: idam.client.cert


### PR DESCRIPTION
### Change description ###
We would like the ability to have Environment names in the secret names be replaced by the set global variable for environment.
This solves the issue if we have environment specific secret names.

*No template version upgrade as non-breaking change*

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```
