### PR TITLE
Update router.tls logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ keyVaults:
 | `registerAdditionalDns.enabled`            | If you want to use this chart as a secondary dependency - e.g. providing a frontend to a backend, and the backend is using primary ingressHost DNS mapping.                            | `false`      
 | `registerAdditionalDns.primaryIngressHost`            | The hostname for primary chart. It supports templating, Example : {{.Release.Name}}.service.core-compute-preview.internal                           | `nil`      
 | `registerAdditionalDns.prefix`            | DNS prefix for this chart - will resolve as: `prefix-{registerAdditionalDns.primaryIngressHost}`                         | `nil`     
-| `disableTraefikTls`            | Boolean value to enable or disable TLS on application specific HTTP router created on Traefik ingress controller                           | `false`
+| `disableTraefikTls`            | Boolean value to enable or disable TLS on application specific HTTP router created on Traefik ingress controller. This will usually be set by Jenkins through global which takes precedence over app settings.                           | `false`
 | `enableOAuth`            | Boolean value to enable or disable OAuth2 proxy. Setting to `true` will force signing into Azure AD when navigating to application frontend            | `false`
 
 ### Pod Disruption Budget

--- a/library/templates/v2/_ingress.tpl
+++ b/library/templates/v2/_ingress.tpl
@@ -3,6 +3,7 @@
 {{- if hasKey .Values "language" -}}
 {{- $languageValues = (deepCopy .Values | merge (pluck .Values.language .Values | first) ) -}}
 {{- end -}}
+{{- $globals := $languageValues.global | default dict -}}
 {{ if or ($languageValues.ingressHost ) ($languageValues.registerAdditionalDns.enabled) }}
 ---
 apiVersion: networking.k8s.io/v1
@@ -14,7 +15,7 @@ metadata:
     {{- if not $languageValues.disableIngressClassAnnotation }}
     kubernetes.io/ingress.class: {{ $languageValues.ingressClass }}
     {{- end }}
-    {{- if not $languageValues.disableTraefikTls }}
+    {{- if not ($globals.disableTraefikTls | default $languageValues.disableTraefikTls) }}
     traefik.ingress.kubernetes.io/router.tls: "true"
     {{- end }}
     {{- if $languageValues.enableOAuth }}


### PR DESCRIPTION
Part 1) from https://tools.hmcts.net/jira/browse/DTSPO-9250.

First need to see if the flag has been set globally via Jenkins, if not default to the app level and continue with the previous logic we had of defaulting `router.tls` to true to keep SDS apps from updating anything. This allows us to disable TLS via Jenkins global flags as part 4) in the same ticket. Will test in a release here and a release in chart-java/node with plum.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
