### PR TITLE
Update if statement to work correctly

### DIFF
--- a/library/templates/v2/_ingress.tpl
+++ b/library/templates/v2/_ingress.tpl
@@ -15,7 +15,7 @@ metadata:
     {{- if not $languageValues.disableIngressClassAnnotation }}
     kubernetes.io/ingress.class: {{ $languageValues.ingressClass }}
     {{- end }}
-    {{- if not ($globals.disableTraefikTls | default $languageValues.disableTraefikTls) }}
+    {{- if not (hasKey $globals "disableTraefikTls" | ternary $globals.disableTraefikTls $languageValues.disableTraefikTls) }}
     traefik.ingress.kubernetes.io/router.tls: "true"
     {{- end }}
     {{- if $languageValues.enableOAuth }}


### PR DESCRIPTION
Previously when `$globals.disableTraefikTls` was set to `false`, it would treat this as empty and always default to the app level definition. This code checks if the global flag exists, if true pick from global level, otherwise pick from app level. http://masterminds.github.io/sprig/defaults.html.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
