### PR TITLE
Make instance label as release name without overrides

### DIFF
--- a/library/templates/v2/_deployment_test_helpers.tpl
+++ b/library/templates/v2/_deployment_test_helpers.tpl
@@ -3,7 +3,7 @@ metadata:
   name: {{ .Release.Name }}-{{ .Values.task }}{{ .Values.type }}-job
   labels:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}-{{ .Values.task }}{{ .Values.type }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app.kubernetes.io/name: {{ template "hmcts.releasename.v2" . }}-{{ .Values.task }}{{ .Values.type }}
 {{- end -}}

--- a/library/templates/v2/_labels.tpl
+++ b/library/templates/v2/_labels.tpl
@@ -14,7 +14,7 @@ labels:
   app.kubernetes.io/name: {{ template "hmcts.releasename.v2" . }}
   helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
   app.kubernetes.io/managed-by: {{ .Release.Service }}
-  app.kubernetes.io/instance: {{ template "hmcts.releasename.v2" . }}
+  app.kubernetes.io/instance: {{ .Release.Name }}
   {{- if $languageValues.aadIdentityName }}
   aadpodidbinding: {{ $languageValues.aadIdentityName }}
   {{- end }}

--- a/tests/results/configmap.yaml
+++ b/tests/results/configmap.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: release-name-library
     helm.sh/chart: library-0.1.0
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/instance: release-name-library
+    app.kubernetes.io/instance: release-name
 data:
   VAR_A: "VALUE_A"
   VAR_B: "VALUE_B"

--- a/tests/results/deployment-tests.yaml
+++ b/tests/results/deployment-tests.yaml
@@ -6,7 +6,7 @@ metadata:
   name: release-name-functionaltestscron-job
   labels:
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/instance: release-name-functionaltestscron
+    app.kubernetes.io/instance: release-name
     helm.sh/chart: library-0.1.0
     app.kubernetes.io/name: release-name-library-functionaltestscron
 spec:

--- a/tests/results/deployment.yaml
+++ b/tests/results/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: release-name-library
     helm.sh/chart: library-0.1.0
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/instance: release-name-library
+    app.kubernetes.io/instance: release-name
   annotations:
 spec:
   revisionHistoryLimit: 0
@@ -22,7 +22,7 @@ spec:
         app.kubernetes.io/name: release-name-library
         helm.sh/chart: library-0.1.0
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/instance: release-name-library
+        app.kubernetes.io/instance: release-name
       annotations:
     spec:
       serviceAccountName: release-name-library

--- a/tests/results/hpa.yaml
+++ b/tests/results/hpa.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: release-name-library
     helm.sh/chart: library-0.1.0
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/instance: release-name-library
+    app.kubernetes.io/instance: release-name
   annotations:
 spec:
   maxReplicas: 5

--- a/tests/results/ingress.yaml
+++ b/tests/results/ingress.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: release-name-library
     helm.sh/chart: library-0.1.0
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/instance: release-name-library
+    app.kubernetes.io/instance: release-name
   annotations:
     kubernetes.io/ingress.class: traefik
 spec:

--- a/tests/results/pdb.yaml
+++ b/tests/results/pdb.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: release-name-library
     helm.sh/chart: library-0.1.0
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/instance: release-name-library
+    app.kubernetes.io/instance: release-name
 spec:
   maxUnavailable: 50%
   selector:

--- a/tests/results/sa.yaml
+++ b/tests/results/sa.yaml
@@ -8,4 +8,4 @@ metadata:
     app.kubernetes.io/name: release-name-library
     helm.sh/chart: library-0.1.0
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/instance: release-name-library
+    app.kubernetes.io/instance: release-name

--- a/tests/results/service.yaml
+++ b/tests/results/service.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: release-name-library
     helm.sh/chart: library-0.1.0
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/instance: release-name-library
+    app.kubernetes.io/instance: release-name
 spec:
   ports:
     - name: http


### PR DESCRIPTION
Currently, there is no label which uniquely distinguishes all pods managed by a helm release. 

https://helm.sh/docs/chart_best_practices/labels/#standard-labels  `app.kubernetes.io/instance` seems to be the one for this purpose. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
