### PR TITLE
Fix for missing globals.environment

### DIFF
--- a/library/templates/v2/_secretproviderclass-tests.tpl
+++ b/library/templates/v2/_secretproviderclass-tests.tpl
@@ -24,14 +24,22 @@ spec:
       array: {{- range $info.secrets }}
      {{- if kindIs "map" . }}
         - |
+        {{- if $globals.environment }}
+          objectName: {{ .name | replace "<ENV>" $globals.environment }} 
+        {{- else }}
           objectName: {{ .name }}
+        {{- end }}
           objectType: secret
         {{- if hasKey . "alias" }}
           objectAlias: {{ .alias }}
         {{- end }}
      {{- else }}
         - |
+        {{- if $globals.environment }}
+          objectName: {{ . | replace "<ENV>" $globals.environment }} 
+        {{- else }}
           objectName: {{ . }}
+        {{- end }}
           objectType: secret
      {{- end }}
       {{- end }}

--- a/library/templates/v2/_secretproviderclass.tpl
+++ b/library/templates/v2/_secretproviderclass.tpl
@@ -24,24 +24,24 @@ spec:
       array: {{- range $info.secrets }}
      {{- if kindIs "map" . }}
         - |
-        {{- if kindIs "string" $globals.environment }}
+        {{- if $globals.environment }}
           objectName: {{ .name | replace "<ENV>" $globals.environment }} 
         {{- else }}
           objectName: {{ .name }}
         {{- end }}
           objectType: secret
-     {{- if hasKey . "alias" }}
+        {{- if hasKey . "alias" }}
           objectAlias: {{ .alias }}
-     {{- end }}
+        {{- end }}
      {{- else }}
         - |
-        {{- if kindIs "string" $globals.environment }}
-          objectName: {{ .name | replace "<ENV>" $globals.environment }} 
+        {{- if $globals.environment }}
+          objectName: {{ . | replace "<ENV>" $globals.environment }} 
         {{- else }}
-          objectName: {{ .name }}
+          objectName: {{ . }}
         {{- end }} 
           objectType: secret
-     {{- end }}
+      {{- end }}
       {{- end }}
 
       {{- range $info.certs }}

--- a/library/templates/v2/_secretproviderclass.tpl
+++ b/library/templates/v2/_secretproviderclass.tpl
@@ -24,14 +24,22 @@ spec:
       array: {{- range $info.secrets }}
      {{- if kindIs "map" . }}
         - |
+        {{- if kindIs "string" $globals.environment }}
           objectName: {{ .name | replace "<ENV>" $globals.environment }} 
+        {{- else }}
+          objectName: {{ .name }}
+        {{- end }}
           objectType: secret
      {{- if hasKey . "alias" }}
           objectAlias: {{ .alias }}
      {{- end }}
      {{- else }}
         - |
-          objectName: {{ . | replace "<ENV>" $globals.environment }} 
+        {{- if kindIs "string" $globals.environment }}
+          objectName: {{ .name | replace "<ENV>" $globals.environment }} 
+        {{- else }}
+          objectName: {{ .name }}
+        {{- end }} 
           objectType: secret
      {{- end }}
       {{- end }}

--- a/library/templates/v2/_secretproviderclass.tpl
+++ b/library/templates/v2/_secretproviderclass.tpl
@@ -41,7 +41,7 @@ spec:
           objectName: {{ . }}
         {{- end }} 
           objectType: secret
-      {{- end }}
+     {{- end }}
       {{- end }}
 
       {{- range $info.certs }}

--- a/library/templates/v2/_secretproviderclass.tpl
+++ b/library/templates/v2/_secretproviderclass.tpl
@@ -49,9 +49,9 @@ spec:
         - |
           objectName: {{ .name }}
           objectType: cert
-     {{- if hasKey . "alias" }}
+        {{- if hasKey . "alias" }}
           objectAlias: {{ .alias }}
-     {{- end }}
+        {{- end }}
      {{- else }}
         - |
           objectName: {{ . }}

--- a/tests/results/secretproviderclass-tests.yaml
+++ b/tests/results/secretproviderclass-tests.yaml
@@ -20,11 +20,11 @@ spec:
           objectName: s2s-secret
           objectType: secret
         - |
-          objectName: idam-client-<ENV>-secret
+          objectName: idam-client-aat-secret
           objectType: secret
           objectAlias: idam.client.env.secret
         - |
-          objectName: s2s-<ENV>-secret
+          objectName: s2s-aat-secret
           objectType: secret
         - |
           objectName: idam-client-cert


### PR DESCRIPTION
Lint failing if globals is set but globals.environment is not set - this fix should allow both to avoid teams having to set a default

"_secretproviderclass.tpl:27:57: executing "hmcts.secretproviderclass.v3.tpl" at <$globals.environment>: wrong type for value; expected string; got interface {}"

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
