### PR TITLE
Add flag logic for adding ingress to DT dashboards

### DIFF
--- a/library/templates/v2/_ingress.tpl
+++ b/library/templates/v2/_ingress.tpl
@@ -18,7 +18,7 @@ metadata:
     {{- if $languageValues.enableOAuth }}
     traefik.ingress.kubernetes.io/router.middlewares: admin-oauth-headers@kubernetescrd,admin-oauth-auth@kubernetescrd
     {{- end }}
-    dtDashboardEnabled: {{ not (hasKey $globals "dtDashboardEnabled") }}
+    dynatraceIngressMonitorsEnabled: {{ not (hasKey $globals "dynatraceIngressMonitorsEnabled") }}
 spec:
   ingressClassName: {{ $languageValues.ingressClass }}
   rules:

--- a/library/templates/v2/_ingress.tpl
+++ b/library/templates/v2/_ingress.tpl
@@ -18,7 +18,7 @@ metadata:
     {{- if $languageValues.enableOAuth }}
     traefik.ingress.kubernetes.io/router.middlewares: admin-oauth-headers@kubernetescrd,admin-oauth-auth@kubernetescrd
     {{- end }}
-    dtdashboardenabled: {{ not (hasKey $globals "dtdashboardenabled") }}
+    dtDashboardEnabled: {{ not (hasKey $globals "dtDashboardEnabled") }}
 spec:
   ingressClassName: {{ $languageValues.ingressClass }}
   rules:

--- a/library/templates/v2/_ingress.tpl
+++ b/library/templates/v2/_ingress.tpl
@@ -18,6 +18,7 @@ metadata:
     {{- if $languageValues.enableOAuth }}
     traefik.ingress.kubernetes.io/router.middlewares: admin-oauth-headers@kubernetescrd,admin-oauth-auth@kubernetescrd
     {{- end }}
+    dtdashboardenabled: {{ not (hasKey $globals "dtdashboardenabled") }}
 spec:
   ingressClassName: {{ $languageValues.ingressClass }}
   rules:

--- a/tests/results/ingress.yaml
+++ b/tests/results/ingress.yaml
@@ -10,7 +10,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
   annotations:
-    dtDashboardEnabled: true
 spec:
   ingressClassName: traefik
   rules:

--- a/tests/results/ingress.yaml
+++ b/tests/results/ingress.yaml
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
   annotations:
+    dtDashboardEnabled: true
 spec:
   ingressClassName: traefik
   rules:

--- a/tests/results/ingress.yaml
+++ b/tests/results/ingress.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
   annotations:
-    dtdashboardenabled: true
+    dtDashboardEnabled: true
 spec:
   ingressClassName: traefik
   rules:

--- a/tests/results/ingress.yaml
+++ b/tests/results/ingress.yaml
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
   annotations:
+    dtdashboardenabled: true
 spec:
   ingressClassName: traefik
   rules:

--- a/tests/results/ingress.yaml
+++ b/tests/results/ingress.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
   annotations:
-    dtDashboardEnabled: true
+    dynatraceIngressMonitorsEnabled: true
 spec:
   ingressClassName: traefik
   rules:


### PR DESCRIPTION
We can set all ingresses to have `dtdashboardenabled:` flag set unless they're deployed via jenkins (preview and aat full of changes to ingresses and generally less useful to check health endpoints compared to other nonprod envs)

This logic will be handled in https://github.com/hmcts/dynatrace-availability-dashboards/pull/76/files for dashboards

PR for jenkins to assign global flag: 

By default, this flag will be set to true so we can grab all ingresses, hence test value. Otherwise, when deployed via jenkins and the global flag exists, we will ignore these ingresses.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
