### PR TITLE
update annotation

### DIFF
--- a/library/templates/v2/_service.tpl
+++ b/library/templates/v2/_service.tpl
@@ -17,7 +17,7 @@ metadata:
   {{- if and $languageValues.ingressSessionAffinity $languageValues.ingressSessionAffinity.enabled }}
   annotations:
     traefik.ingress.kubernetes.io/service.sticky.cookie: "true"
-    traefik.ingress.kubernetes.io/session.cookie.name: {{ $languageValues.ingressSessionAffinity.sessionCookieName | quote }}
+    traefik.ingress.kubernetes.io/service.sticky.cookie.name: {{ $languageValues.ingressSessionAffinity.sessionCookieName | quote }}
   {{- end }}
   {{- end }}
 spec:


### PR DESCRIPTION
Only a few apps use this, mainly docmosis and camunda.  Those are working because they pull from chart-base which hasn't taken this https://github.com/hmcts/chart-library/releases/tag/1.1.4 most recent release yet, it's still on 1.1.0

Private-law are facing an issue where sessions are not sticking, because they have moved to this latest chart, they don't have the old annotations which seem to still work

The docs show these should be set as:

![image](https://user-images.githubusercontent.com/47995122/205702825-d4c3b15b-2cfb-482e-99b2-c616e027770d.png)

https://doc.traefik.io/traefik/routing/providers/kubernetes-ingress/#on-service

Can test this with beta library and node chart with the private-law team
https://cs.github.com/?scopeName=All+repos&scope=&q=traefik.ingress.kubernetes.io%2Fservice.sticky.cookie.name - using the annotation from docs

https://cs.github.com/?scopeName=All+repos&scope=&q=traefik.ingress.kubernetes.io%2Fsession.cookie.name - using the one we currently have set

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
