### PR TITLE
Update ingress template

### DIFF
--- a/library/templates/v2/_ingress.tpl
+++ b/library/templates/v2/_ingress.tpl
@@ -15,7 +15,7 @@ metadata:
     {{- if not (hasKey $globals "disableTraefikTls" | ternary $globals.disableTraefikTls $languageValues.disableTraefikTls) }}
     traefik.ingress.kubernetes.io/router.tls: "true"
     {{- end }}
-    {{* TODO remove after https://github.com/kubernetes-sigs/external-dns/issues/2386 is solved *}}
+    # TODO remove after https://github.com/kubernetes-sigs/external-dns/issues/2386 is solved
     external-dns-selector: {{ $languageValues.ingressClass }}
     {{- if $languageValues.enableOAuth }}
     traefik.ingress.kubernetes.io/router.middlewares: admin-oauth-headers@kubernetescrd,admin-oauth-auth@kubernetescrd

--- a/library/templates/v2/_ingress.tpl
+++ b/library/templates/v2/_ingress.tpl
@@ -15,6 +15,7 @@ metadata:
     {{- if not (hasKey $globals "disableTraefikTls" | ternary $globals.disableTraefikTls $languageValues.disableTraefikTls) }}
     traefik.ingress.kubernetes.io/router.tls: "true"
     {{- end }}
+    external-dns-selector: {{ $languageValues.ingressClass }}
     {{- if $languageValues.enableOAuth }}
     traefik.ingress.kubernetes.io/router.middlewares: admin-oauth-headers@kubernetescrd,admin-oauth-auth@kubernetescrd
     {{- end }}

--- a/library/templates/v2/_ingress.tpl
+++ b/library/templates/v2/_ingress.tpl
@@ -15,7 +15,7 @@ metadata:
     {{- if not (hasKey $globals "disableTraefikTls" | ternary $globals.disableTraefikTls $languageValues.disableTraefikTls) }}
     traefik.ingress.kubernetes.io/router.tls: "true"
     {{- end }}
-    # TODO remove after https://github.com/kubernetes-sigs/external-dns/issues/2386 is solved
+    {{* TODO remove after https://github.com/kubernetes-sigs/external-dns/issues/2386 is solved *}}
     external-dns-selector: {{ $languageValues.ingressClass }}
     {{- if $languageValues.enableOAuth }}
     traefik.ingress.kubernetes.io/router.middlewares: admin-oauth-headers@kubernetescrd,admin-oauth-auth@kubernetescrd

--- a/library/templates/v2/_ingress.tpl
+++ b/library/templates/v2/_ingress.tpl
@@ -15,6 +15,7 @@ metadata:
     {{- if not (hasKey $globals "disableTraefikTls" | ternary $globals.disableTraefikTls $languageValues.disableTraefikTls) }}
     traefik.ingress.kubernetes.io/router.tls: "true"
     {{- end }}
+    # TODO remove after https://github.com/kubernetes-sigs/external-dns/issues/2386 is solved
     external-dns-selector: {{ $languageValues.ingressClass }}
     {{- if $languageValues.enableOAuth }}
     traefik.ingress.kubernetes.io/router.middlewares: admin-oauth-headers@kubernetescrd,admin-oauth-auth@kubernetescrd

--- a/tests/results/ingress.yaml
+++ b/tests/results/ingress.yaml
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
   annotations:
+    # TODO remove after https://github.com/kubernetes-sigs/external-dns/issues/2386 is solved
     external-dns-selector: traefik
 spec:
   ingressClassName: traefik

--- a/tests/results/ingress.yaml
+++ b/tests/results/ingress.yaml
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
   annotations:
+    external-dns-selector: traefik
 spec:
   ingressClassName: traefik
   rules:


### PR DESCRIPTION
Since removing deprecated annotation when [migrating to traefik2](https://github.com/hmcts/chart-library/commit/c5af35d46cd13078c68294d9d5c62080f83f0e94), external-dns selector is no longer functional and has stopped working in SDS, likely responsible for some demo issues in the past few months as well, as private and public external-dns deployments are likely fighting over the same named zone (public and private).

This PR would add a new custom annotation, so that external-dns (only envs where we run public and private) can distinguish between the two types of records using the annotation filter https://github.com/hmcts/sds-flux-config/blob/master/apps/admin/external-dns/external-dns.yaml#L27

In this case, any ingress objects with traefik, or traefik-no-proxy would be handled by external-dns-public, and any other by external dns private (will require change to sds and cnp-flux)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
