### PR TITLE
Reverting withdrawn functionality from chart-library

### DIFF
--- a/library/templates/v2/_ingress.tpl
+++ b/library/templates/v2/_ingress.tpl
@@ -15,8 +15,6 @@ metadata:
     {{- if not (hasKey $globals "disableTraefikTls" | ternary $globals.disableTraefikTls $languageValues.disableTraefikTls) }}
     traefik.ingress.kubernetes.io/router.tls: "true"
     {{- end }}
-    # TODO remove after https://github.com/kubernetes-sigs/external-dns/issues/2386 is solved
-    external-dns-selector: {{ $languageValues.ingressClass }}
     {{- if $languageValues.enableOAuth }}
     traefik.ingress.kubernetes.io/router.middlewares: admin-oauth-headers@kubernetescrd,admin-oauth-auth@kubernetescrd
     {{- end }}

--- a/tests/results/ingress.yaml
+++ b/tests/results/ingress.yaml
@@ -10,8 +10,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: release-name
   annotations:
-    # TODO remove after https://github.com/kubernetes-sigs/external-dns/issues/2386 is solved
-    external-dns-selector: traefik
 spec:
   ingressClassName: traefik
   rules:


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-12427

Change to fix split-horizon DNS in demo is no longer needed when moving to active/active configuration and removing external-dns. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
