### PR TITLE
Upgrade csi driver API version

### DIFF
--- a/library/templates/v2/_secretproviderclass-tests.tpl
+++ b/library/templates/v2/_secretproviderclass-tests.tpl
@@ -1,4 +1,4 @@
-{{- define "hmcts.secretproviderclass-tests.v2.tpl" -}}
+{{- define "hmcts.secretproviderclass-tests.v3.tpl" -}}
 {{- $languageValues := deepCopy .Values -}}
 {{- if hasKey .Values "language" -}}
 {{- $languageValues = (deepCopy .Values | merge (pluck .Values.language .Values | first) ) -}}
@@ -10,7 +10,7 @@
 {{- range $vault, $info := $languageValues.testsConfig.keyVaults }}
 {{- if not $info.disabled }}
 ---
-apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+apiVersion: secrets-store.csi.x-k8s.io/v1
 kind: SecretProviderClass
 metadata:
   name: {{ template "hmcts.releasename.v2" $root }}-tests-{{ $vault }}

--- a/library/templates/v2/_secretproviderclass.tpl
+++ b/library/templates/v2/_secretproviderclass.tpl
@@ -1,4 +1,4 @@
-{{- define "hmcts.secretproviderclass.v3.tpl" -}}
+{{- define "hmcts.secretproviderclass.v4.tpl" -}}
 {{- $languageValues := deepCopy .Values -}}
 {{- if hasKey .Values "language" -}}
 {{- $languageValues = (deepCopy .Values | merge (pluck .Values.language .Values | first) ) -}}
@@ -10,7 +10,7 @@
 {{- range $vault, $info := $languageValues.keyVaults }}
 {{- if not $info.disabled }}
 ---
-apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+apiVersion: secrets-store.csi.x-k8s.io/v1
 kind: SecretProviderClass
 metadata:
   name: {{ template "hmcts.releasename.v2" $root }}-{{ $vault }}

--- a/library/templates/v2/secretproviderclass-tests.yaml
+++ b/library/templates/v2/secretproviderclass-tests.yaml
@@ -1,1 +1,1 @@
-{{- template "hmcts.secretproviderclass-tests.v2.tpl" . -}}
+{{- template "hmcts.secretproviderclass-tests.v3.tpl" . -}}

--- a/library/templates/v2/secretproviderclass.yaml
+++ b/library/templates/v2/secretproviderclass.yaml
@@ -1,1 +1,1 @@
-{{- template "hmcts.secretproviderclass.v3.tpl" . -}}
+{{- template "hmcts.secretproviderclass.v4.tpl" . -}}

--- a/library/tests/snapshot-tests/__snapshot__/secretproviderclass-tests_test.yaml.snap
+++ b/library/tests/snapshot-tests/__snapshot__/secretproviderclass-tests_test.yaml.snap
@@ -1,6 +1,6 @@
 manifest should match snapshot:
   1: |
-    apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+    apiVersion: secrets-store.csi.x-k8s.io/v1
     kind: SecretProviderClass
     metadata:
       name: release-name-library-tests-bulk-scan

--- a/library/tests/snapshot-tests/__snapshot__/secretproviderclass_test.yaml.snap
+++ b/library/tests/snapshot-tests/__snapshot__/secretproviderclass_test.yaml.snap
@@ -1,6 +1,6 @@
 manifest should match snapshot:
   1: |
-    apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+    apiVersion: secrets-store.csi.x-k8s.io/v1
     kind: SecretProviderClass
     metadata:
       name: release-name-library-bulk-scan

--- a/library/tests/snapshot-tests/__snapshot__/secretproviderclass_test.yaml.snap
+++ b/library/tests/snapshot-tests/__snapshot__/secretproviderclass_test.yaml.snap
@@ -35,7 +35,7 @@ manifest should match snapshot:
         userAssignedIdentityID: ""
       provider: azure
   2: |
-    apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+    apiVersion: secrets-store.csi.x-k8s.io/v1
     kind: SecretProviderClass
     metadata:
       name: release-name-library-bulk-scan-v2

--- a/tests/v2/secretproviderclass-tests.yaml
+++ b/tests/v2/secretproviderclass-tests.yaml
@@ -1,1 +1,1 @@
-{{- template "hmcts.secretproviderclass-tests.v2.tpl" . -}}
+{{- template "hmcts.secretproviderclass-tests.v3.tpl" . -}}

--- a/tests/v2/secretproviderclass.yaml
+++ b/tests/v2/secretproviderclass.yaml
@@ -1,1 +1,1 @@
-{{- template "hmcts.secretproviderclass.v3.tpl" . -}}
+{{- template "hmcts.secretproviderclass.v4.tpl" . -}}


### PR DESCRIPTION
Noticed all our builds getting:

```
W0912 10:57:12.151084    2036 warnings.go:70] secrets-store.csi.x-k8s.io/v1alpha1 is deprecated. Use secrets-store.csi.x-k8s.io/v1 instead.
W0912 10:57:12.311069    2036 warnings.go:70] secrets-store.csi.x-k8s.io/v1alpha1 is deprecated. Use secrets-store.csi.x-k8s.io/v1 instead.
```