### PR TITLE
Bug when users define their own affinity settings

### DIFF
--- a/library/templates/v2/_affinity.tpl
+++ b/library/templates/v2/_affinity.tpl
@@ -8,6 +8,7 @@ Setup pod affinity rules
 {{- $languageValues = (deepCopy .Values | merge (pluck .Values.language .Values | first) ) -}}
 {{- end -}}
 {{ if $languageValues.affinity }}
+affinity:
 {{ toYaml $languageValues.affinity | indent 2 }}
 {{- else }}
 affinity:


### PR DESCRIPTION
### Change description ###
Bug when users define their own affinity settings, missing the affinity key in template as the toYaml will only format the values found not the key

